### PR TITLE
qBraid debugging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # 
-FROM python:3.10-slim
+FROM --platform=linux/amd64 python:3.10-slim
 
 # 
 WORKDIR /code

--- a/app/quantum/teleportation.py
+++ b/app/quantum/teleportation.py
@@ -69,11 +69,11 @@ def qbraid_teleportation_experiment(N):
     # Run the simulation
     # run_input = [qiskit_circuit]
 
-    jobs = device.run(qiskit_circuit, shots=N)
-    results = [job.result() for job in jobs]
+    job = device.run(qiskit_circuit, shots=N)
+    result = job.result()
     
     # Analyze results
-    counts = results[0].raw_counts()
+    counts = result.data.get_counts()
     print(counts)
     success_rate = 100
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ qiskit==1.2.1
 qiskit-aer==0.15.0
 qiskit-ibm-runtime==0.30.0
 requests==2.32.3
-qbraid==0.8.3
+qbraid[qir]==0.8.3
 prometheus-fastapi-instrumentator==7.0.0
 opentelemetry-distro==0.45b0
 opentelemetry-instrumentation-fastapi==0.45b0


### PR DESCRIPTION
In reference to https://github.com/qBraid/qBraid/issues/790:

I was able to recreate the `TypeError: 'QuantumCircuit' object is not a mapping`, and figured out that this was occurring because `qbraid-qir` was not installed, see https://docs.qbraid.com/sdk/user-guide/providers/native#installation-and-setup

It was trying to unpack a dictionary which should contain the QIR bytecode, but the transpilation from qiskit to QIR failed, but for some reason failed to raise an exception. This exception handling (or lack thereof) will be raised as a separate qBraid-SDK issue.

So coming back to your issue, adding the `qbraid[qir]` dependency fixes that part. However, after making that update, the docker build was then failing during installation of `requirements.txt` due to failure to find a matching distribution for "pyqir". This seemed to be because whatever platform the `python:3.10-slim` docker image uses isn't support by `pyqir`, because adding a `--platform=linux/amd64` flag to the base image instruction fixed it for me.

Finally, made some syntax fixes to the retrieval of results and pipeline then worked for me. I'm still a little unsure about the `pyqir` distribution / platform compatibility thing. I can help look into that further as needed. But for now, either that explicit platform flag or a `buildx` config should be sufficient workarounds. 
