### PR TITLE
fix unpacking bug

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -103,9 +103,11 @@ def execute_qbraid_teleportation(
         raise ValueError("Number of executions must be a positive integer")
 
     # Pass the API key from settings to the experiment function
-    success_rate, counts = qbraid_teleportation_experiment(executions)
+    success_rate, counts, payload, depth = qbraid_teleportation_experiment(executions)
     
     return {
         "success_rate": success_rate,
-        "counts": counts
+        "counts": counts,
+        "depth": depth,
+        "payload": payload
     }


### PR DESCRIPTION
I wasn't able to recreate the `NodeNotFoundError` that you mentioned in https://github.com/qBraid/qBraid/issues/790#issuecomment-2420240729.

However, I did find a different `ValueError: too many values to unpack` where you call `qbraid_teleportation_experiment()`. After I fixed that, the application worked for me! It's very cool.

Are you still experiencing the `NodeNotFoundError`?